### PR TITLE
remove slack channel names in favor of IDs

### DIFF
--- a/cmd/lambda.go
+++ b/cmd/lambda.go
@@ -22,9 +22,8 @@ const (
 )
 
 var (
-	errProcessorInvalidLabelMatch    = errors.New("invalid label match (must be 'label=value')")
-	errSlackChannelIDNotConfigured   = errors.New("slack channel ID must be configured")
-	errSlackChannelNameNotConfigured = errors.New("slack channel name must be configured")
+	errProcessorInvalidLabelMatch  = errors.New("invalid label match (must be 'label=value')")
+	errSlackChannelIDNotConfigured = errors.New("slack channel ID must be configured")
 )
 
 func CommandLambda(cfg *config.Config) *cli.Command {
@@ -76,14 +75,6 @@ func CommandLambda(cfg *config.Config) *cli.Command {
 	flagsSlack := []cli.Flag{
 		&cli.StringFlag{
 			Category:    categorySlack,
-			Destination: &cfg.Slack.Channel.Name,
-			EnvVars:     []string{envPrefix + envPrefixSlack + "CHANNEL_NAME"},
-			Name:        cliPrefixSlack + "channel-name",
-			Usage:       "slack channel `name` to publish alerts to",
-		},
-
-		&cli.StringFlag{
-			Category:    categorySlack,
 			Destination: &cfg.Slack.Channel.ID,
 			EnvVars:     []string{envPrefix + envPrefixSlack + "CHANNEL_ID"},
 			Name:        cliPrefixSlack + "channel-id",
@@ -127,9 +118,6 @@ func CommandLambda(cfg *config.Config) *cli.Command {
 			if cfg.Slack.Token != "" {
 				if cfg.Slack.Channel.ID == "" {
 					return errSlackChannelIDNotConfigured
-				}
-				if cfg.Slack.Channel.Name == "" {
-					return errSlackChannelNameNotConfigured
 				}
 
 				cfg.Slack.Token, err = stringOrLoadFromSecretsmanager(cfg.Slack.Token, envSlackToken)

--- a/config/slack.go
+++ b/config/slack.go
@@ -7,5 +7,5 @@ type Slack struct {
 
 func (s *Slack) Enabled() bool {
 	return s.Token != "" &&
-		s.Channel != nil && s.Channel.ID != "" && s.Channel.Name != ""
+		s.Channel != nil && s.Channel.ID != ""
 }

--- a/config/slack_channel.go
+++ b/config/slack_channel.go
@@ -1,6 +1,5 @@
 package config
 
 type SlackChannel struct {
-	ID   string `yaml:"id"`
-	Name string `yaml:"name"`
+	ID string `yaml:"id"`
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -39,7 +39,7 @@ func New(cfg *config.Config) (*Processor, error) {
 	if cfg.Slack.Enabled() {
 		slack, err := publisher.NewSlackChannel(
 			cfg.Slack,
-			db.WithNamespace("slack-"+cfg.Slack.Channel.Name),
+			db.WithNamespace("slack-"+cfg.Slack.Channel.ID),
 		)
 		if err != nil {
 			return nil, err

--- a/publisher/slack.go
+++ b/publisher/slack.go
@@ -21,8 +21,7 @@ import (
 )
 
 type slackChannel struct {
-	channelID   string
-	channelName string
+	channelID string
 
 	cli slackApi
 	db  db.DB
@@ -40,8 +39,7 @@ var (
 
 func NewSlackChannel(cfg *config.Slack, db db.DB) (Publisher, error) {
 	return &slackChannel{
-		channelName: cfg.Channel.Name,
-		channelID:   cfg.Channel.ID,
+		channelID: cfg.Channel.ID,
 
 		cli: slack.New(cfg.Token),
 		db:  db,
@@ -55,8 +53,8 @@ func (s *slackChannel) Publish(
 ) (err error) {
 	l := logutils.LoggerFromContext(ctx)
 
-	dbKeyThreadTS := source + "/" + s.channelName + "/" + alert.IncidentDedupKey()
-	dbKeyMessageTS := source + "/" + s.channelName + "/" + alert.MessageDedupKey()
+	dbKeyThreadTS := source + "/" + s.channelID + "/" + alert.IncidentDedupKey()
+	dbKeyMessageTS := source + "/" + s.channelID + "/" + alert.MessageDedupKey()
 
 	var messageTS, threadTS string
 
@@ -207,11 +205,11 @@ func (s *slackChannel) publishMessage(
 		)
 	}
 
-	_, messageTS, err := s.cli.PostMessage(s.channelName, opts...)
+	_, messageTS, err := s.cli.PostMessage(s.channelID, opts...)
 	if err != nil {
 		l.Error("Error publishing message to slack",
 			zap.Error(err),
-			zap.String("slack_channel", s.channelName),
+			zap.String("slack_channel_id", s.channelID),
 			zap.String("slack_message_ts", messageTS),
 			zap.String("slack_thread_ts", threadTS),
 		)
@@ -259,7 +257,7 @@ func (s *slackChannel) updateReaction(
 	}(); err != nil {
 		l.Error("Error adding reaction to slack",
 			zap.Error(err),
-			zap.String("slack_channel", s.channelName),
+			zap.String("slack_channel_id", s.channelID),
 			zap.String("slack_reaction", ra),
 			zap.String("slack_thread_ts", threadTS),
 		)
@@ -284,7 +282,7 @@ func (s *slackChannel) updateReaction(
 	}(); err != nil {
 		l.Error("Error removing reaction from slack",
 			zap.Error(err),
-			zap.String("slack_channel", s.channelName),
+			zap.String("slack_channel_id", s.channelID),
 			zap.String("slack_reaction", rr),
 			zap.String("slack_thread_ts", threadTS),
 		)

--- a/publisher/slack_test.go
+++ b/publisher/slack_test.go
@@ -58,8 +58,7 @@ func setupSlackPublisher(t *testing.T) (
 	slack, err := NewSlackChannel(&config.Slack{
 		Token: "testToken",
 		Channel: &config.SlackChannel{
-			ID:   "testChannelID",
-			Name: "testChannelName",
+			ID: "testChannelID",
 		},
 	}, db)
 	assert.NoError(t, err, "unexpected error while creating slack publisher")
@@ -82,30 +81,30 @@ func TestSlackOpeningAlert(t *testing.T) {
 	}()
 
 	db.EXPECT().
-		Get(ctx, "testSource/testChannelName/"+alert.MessageDedupKey()).
+		Get(ctx, "testSource/testChannelID/"+alert.MessageDedupKey()).
 		Return("", nil)
 
 	db.EXPECT().
-		Lock(ctx, "testSource/testChannelName/"+alert.MessageDedupKey(), timeoutLock).
+		Lock(ctx, "testSource/testChannelID/"+alert.MessageDedupKey(), timeoutLock).
 		Return(true, nil)
 
 	db.EXPECT().
-		Get(ctx, "testSource/testChannelName/"+alert.IncidentDedupKey()).
+		Get(ctx, "testSource/testChannelID/"+alert.IncidentDedupKey()).
 		Return("", nil) // no thread exists
 
 	slack.EXPECT().
-		PostMessage("testChannelName", gomock.Any()).
+		PostMessage("testChannelID", gomock.Any()).
 		DoAndReturn(func(channelID string, options ...slack_api.MsgOption) (string, string, error) {
-			assert.Equal(t, "testChannelName", channelID)
+			assert.Equal(t, "testChannelID", channelID)
 			assert.Equal(t, 1, len(options))
 			return "", "testMessageTS", nil
 		})
 
 	db.EXPECT().
-		Set(ctx, "testSource/testChannelName/"+alert.MessageDedupKey(), timeoutThreadExpiry, "testMessageTS")
+		Set(ctx, "testSource/testChannelID/"+alert.MessageDedupKey(), timeoutThreadExpiry, "testMessageTS")
 
 	db.EXPECT().
-		Set(ctx, "testSource/testChannelName/"+alert.IncidentDedupKey(), timeoutThreadExpiry, "testMessageTS")
+		Set(ctx, "testSource/testChannelID/"+alert.IncidentDedupKey(), timeoutThreadExpiry, "testMessageTS")
 
 	slack.EXPECT().
 		RemoveReaction("white_check_mark", gomock.Any()).
@@ -135,27 +134,27 @@ func TestSlackFollowUpAlert(t *testing.T) {
 	}()
 
 	db.EXPECT().
-		Get(ctx, "testSource/testChannelName/"+alert.MessageDedupKey()).
+		Get(ctx, "testSource/testChannelID/"+alert.MessageDedupKey()).
 		Return("", nil)
 
 	db.EXPECT().
-		Lock(ctx, "testSource/testChannelName/"+alert.MessageDedupKey(), timeoutLock).
+		Lock(ctx, "testSource/testChannelID/"+alert.MessageDedupKey(), timeoutLock).
 		Return(true, nil)
 
 	db.EXPECT().
-		Get(ctx, "testSource/testChannelName/"+alert.IncidentDedupKey()).
+		Get(ctx, "testSource/testChannelID/"+alert.IncidentDedupKey()).
 		Return("testThreadTS", nil) // thread exists
 
 	slack.EXPECT().
-		PostMessage("testChannelName", gomock.Any()).
+		PostMessage("testChannelID", gomock.Any()).
 		DoAndReturn(func(channelID string, options ...slack_api.MsgOption) (string, string, error) {
-			assert.Equal(t, "testChannelName", channelID)
+			assert.Equal(t, "testChannelID", channelID)
 			assert.Equal(t, 2, len(options))
 			return "", "testMessageTS", nil
 		})
 
 	db.EXPECT().
-		Set(ctx, "testSource/testChannelName/"+alert.MessageDedupKey(), timeoutThreadExpiry, "testMessageTS")
+		Set(ctx, "testSource/testChannelID/"+alert.MessageDedupKey(), timeoutThreadExpiry, "testMessageTS")
 
 	slack.EXPECT().
 		RemoveReaction("white_check_mark", gomock.Any()).
@@ -185,27 +184,27 @@ func TestSlackResolvingAlert(t *testing.T) {
 	}()
 
 	db.EXPECT().
-		Get(ctx, "testSource/testChannelName/"+alert.MessageDedupKey()).
+		Get(ctx, "testSource/testChannelID/"+alert.MessageDedupKey()).
 		Return("", nil)
 
 	db.EXPECT().
-		Lock(ctx, "testSource/testChannelName/"+alert.MessageDedupKey(), timeoutLock).
+		Lock(ctx, "testSource/testChannelID/"+alert.MessageDedupKey(), timeoutLock).
 		Return(true, nil)
 
 	db.EXPECT().
-		Get(ctx, "testSource/testChannelName/"+alert.IncidentDedupKey()).
+		Get(ctx, "testSource/testChannelID/"+alert.IncidentDedupKey()).
 		Return("testThreadTS", nil) // thread exists
 
 	slack.EXPECT().
-		PostMessage("testChannelName", gomock.Any()).
+		PostMessage("testChannelID", gomock.Any()).
 		DoAndReturn(func(channelID string, options ...slack_api.MsgOption) (string, string, error) {
-			assert.Equal(t, "testChannelName", channelID)
+			assert.Equal(t, "testChannelID", channelID)
 			assert.Equal(t, 2, len(options))
 			return "", "testMessageTS", nil
 		})
 
 	db.EXPECT().
-		Set(ctx, "testSource/testChannelName/"+alert.MessageDedupKey(), timeoutThreadExpiry, "testMessageTS")
+		Set(ctx, "testSource/testChannelID/"+alert.MessageDedupKey(), timeoutThreadExpiry, "testMessageTS")
 
 	slack.EXPECT().
 		RemoveReaction("rotating_light", gomock.Any()).
@@ -235,7 +234,7 @@ func TestSlackDuplicateAlert(t *testing.T) {
 	}()
 
 	db.EXPECT().
-		Get(ctx, "testSource/testChannelName/"+alert.MessageDedupKey()).
+		Get(ctx, "testSource/testChannelID/"+alert.MessageDedupKey()).
 		Return("testMessageTX", nil) // duplicate alert
 
 }

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,6 @@ amp-alerts-sink lambda \
   --processor-ignore-rules DatasourceError \
   --processor-match-labels foo=bar \
   --publisher-slack-channel-id XXXXXXXXXXX \
-  --publisher-slack-channel-name alerts \
   --publisher-slack-token arn:aws:secretsmanager:rrr:aaa:secret:sss
 ```
 


### PR DESCRIPTION
Slack supports sending messages by [channel ID](https://api.slack.com/methods/chat.postMessage#:~:text=encoded%20ID%20or%20channel%20name), we don't need to rely on (potentially) non-constant channel name.

This will break backwards compatibility with DB schema, and some currently firing alerts will be stuck as firing in Slack.