### PR TITLE
Add more links to messages

### DIFF
--- a/publisher/slack.go
+++ b/publisher/slack.go
@@ -174,6 +174,21 @@ func (s *slackChannel) newMessage(
 		msg.Text += fmt.Sprintf("Kubernetes namespace: `%s`\n", namespace)
 	}
 
+	var links []string
+	addLink := func(href, text string) {
+		if href == "" {
+			return
+		}
+		links = append(links, fmt.Sprintf("<%s|%s>", href, text))
+	}
+	addLink(alert.Annotations["runbook_url"], "📕 Runbook")
+	addLink(alert.GeneratorURL, "📈 Expr")
+	addLink(alert.SilenceURL, "🔕 Silence")
+
+	if len(links) > 0 {
+		msg.Text += fmt.Sprintf("\n%s\n", strings.Join(links, " | "))
+	}
+
 	return msg
 }
 

--- a/types/alert_manager_message.go
+++ b/types/alert_manager_message.go
@@ -1,8 +1,0 @@
-package types
-
-type AlertmanagerMessage struct {
-	Alerts            []AlertmanagerAlert `json:"alerts"`
-	CommonAnnotations map[string]string   `json:"commonAnnotations"`
-	CommonLabels      map[string]string   `json:"commonLabels"`
-	Status            string              `json:"status"`
-}

--- a/types/types.go
+++ b/types/types.go
@@ -7,11 +7,27 @@ import (
 	"slices"
 )
 
+type AlertmanagerMessage struct {
+	Status            string              `json:"status"`
+	Alerts            []AlertmanagerAlert `json:"alerts"`
+	CommonLabels      map[string]string   `json:"commonLabels"`
+	CommonAnnotations map[string]string   `json:"commonAnnotations"`
+}
+
 type AlertmanagerAlert struct {
-	Annotations map[string]string `json:"annotations"`
+	Status   string `json:"status"`
+	StartsAt string `json:"startsAt"`
+
+	GeneratorURL string `json:"generatorURL"`
+
+	// SilenceURL is a field included by default in Grafana Alertmanager alerts.
+	// However, it can be included in any Alertmanager notification template,
+	// and will get added to rendered alerts from amp-alerts-sink.
+	// Ignored if unset.
+	SilenceURL string `json:"silenceURL"`
+
 	Labels      map[string]string `json:"labels"`
-	StartsAt    string            `json:"startsAt"`
-	Status      string            `json:"status"`
+	Annotations map[string]string `json:"annotations"`
 }
 
 // IncidentDedupKey computes the hash of alert's labels only.


### PR DESCRIPTION
Parse generatorURL (backlink to alert expr), silenceURL and runbook_url,
if set. Include in both Slack messages and Pagerduty incidents.
