### PR TITLE
Change incident fields in pagerduty, more logs

### DIFF
--- a/mock/publisher/pagerduty.go
+++ b/mock/publisher/pagerduty.go
@@ -11,6 +11,7 @@ package mock_publisher
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	pagerduty "github.com/PagerDuty/go-pagerduty"
@@ -39,6 +40,21 @@ func NewMock_pagerDutyClient(ctrl *gomock.Controller) *Mock_pagerDutyClient {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *Mock_pagerDutyClient) EXPECT() *Mock_pagerDutyClientMockRecorder {
 	return m.recorder
+}
+
+// LastAPIResponse mocks base method.
+func (m *Mock_pagerDutyClient) LastAPIResponse() (*http.Response, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LastAPIResponse")
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// LastAPIResponse indicates an expected call of LastAPIResponse.
+func (mr *Mock_pagerDutyClientMockRecorder) LastAPIResponse() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastAPIResponse", reflect.TypeOf((*Mock_pagerDutyClient)(nil).LastAPIResponse))
 }
 
 // ManageEventWithContext mocks base method.

--- a/publisher/pagerduty.go
+++ b/publisher/pagerduty.go
@@ -43,10 +43,7 @@ func (p pagerDuty) Publish(
 
 	defer func() {
 		if err != nil {
-			l.Error("Failed to publish alert to pagerduty",
-				zap.Error(err),
-				zap.Any("alert", alert),
-			)
+			l.Error("Failed to publish alert to pagerduty", zap.Error(err))
 
 			// If we fail to publish the alert, we should publish another alert
 			// to notify that something is wrong.
@@ -88,26 +85,54 @@ func (p pagerDuty) Publish(
 		}
 	}()
 
-	action := "trigger"
+	event := &pagerduty.V2Event{
+		RoutingKey: p.integrationKey,
+		DedupKey:   alert.IncidentDedupKey(),
+		Payload: &pagerduty.V2Payload{
+			Timestamp: alert.StartsAt,
+			Class:     alert.Labels["alertname"],
+		},
+	}
+
+	event.Action = "trigger"
 	if alert.Status == "resolved" {
-		action = "resolve"
+		event.Action = "resolve"
 	}
 
-	summary := alert.Labels["alertname"]
-	if alert.Annotations["summary"] != "" {
-		summary += fmt.Sprint(": ", alert.Annotations["summary"])
-	}
-
-	var links []any
 	addLink := func(href, text string) {
 		if href == "" {
 			return
 		}
-		links = append(links, map[string]string{"href": href, "text": text})
+		event.Links = append(event.Links, map[string]string{"href": href, "text": text})
 	}
 	addLink(alert.Annotations["runbook_url"], "📕 Runbook")
 	addLink(alert.GeneratorURL, "📈 Expr")
 	addLink(alert.SilenceURL, "🔕 Silence")
+
+	// Use SNS topic ARN, unless the "source" label is set
+	event.Client = source
+	if src := alert.Labels["source"]; src != "" {
+		event.Client = src
+	}
+	event.ClientURL = alert.GeneratorURL
+
+	event.Payload.Summary = alert.Labels["alertname"]
+	if summary := alert.Annotations["summary"]; summary != "" {
+		event.Payload.Summary += ": " + summary
+	}
+
+	// "instance" is set by scraper, but "instance_name" is more readable
+	// Source in payload should be "unique location of the affected system"
+	// as per PagerDuty docs
+	event.Payload.Source = alert.Labels["instance"]
+	if src := alert.Labels["instance_name"]; src != "" {
+		event.Payload.Source = src
+	}
+	if event.Payload.Source == "" {
+		// If no source is set, set dummy value.
+		// This field is required by PagerDuty API.
+		event.Payload.Source = "unknown"
+	}
 
 	severity := alert.Labels["severity"]
 	if !slices.Contains([]string{"critical", "warning", "error", "info"}, severity) {
@@ -115,30 +140,20 @@ func (p pagerDuty) Publish(
 		// On invalid severity, PagerDuty will not create an incident.
 		severity = "critical"
 	}
-
-	event := &pagerduty.V2Event{
-		RoutingKey: p.integrationKey,
-		Action:     action,
-		DedupKey:   alert.IncidentDedupKey(),
-		Links:      links,
-		ClientURL:  alert.GeneratorURL,
-		Payload: &pagerduty.V2Payload{
-			Source:    source,
-			Timestamp: alert.StartsAt,
-			Summary:   summary,
-			Severity:  severity,
-			Class:     alert.Labels["alertname"],
-		},
-	}
+	event.Payload.Severity = severity
 
 	details := maps.Clone(alert.Labels)
 	delete(details, "severity")
 	delete(details, "alertname")
 	maps.Copy(details, alert.Annotations)
 	delete(details, "summary")
-	delete(details, "generatorURL")
 	event.Payload.Details = details
 
+	l.Info(
+		"Publishing alert to pagerduty",
+		zap.Any("alert", alert),
+		zap.Any("event", event),
+	)
 	resp, err := p.client.ManageEventWithContext(ctx, event)
 	if err != nil {
 		return err
@@ -146,8 +161,6 @@ func (p pagerDuty) Publish(
 	if len(resp.Errors) > 0 {
 		return fmt.Errorf("pagerduty: %v", resp.Errors)
 	}
-	l.Info("Published alert to pagerduty",
-		zap.Any("alert", alert),
-	)
+	l.Info("Successfully published to pagerduty")
 	return nil
 }

--- a/publisher/pagerduty.go
+++ b/publisher/pagerduty.go
@@ -52,14 +52,18 @@ func (p pagerDuty) Publish(
 
 			errResp, ok := p.client.LastAPIResponse()
 			if ok && errResp != nil {
-				// ignore the errors, we don't care
-				body, _ := io.ReadAll(errResp.Body)
+				body, err := io.ReadAll(errResp.Body)
 
-				l.Error("PagerDuty API response",
+				logFields := []zap.Field{
 					zap.String("status", errResp.Status),
 					zap.String("headers", fmt.Sprintf("%+v", errResp.Header)),
 					zap.String("body", string(body)),
-				)
+				}
+				if err != nil {
+					logFields = append(logFields, zap.Error(err))
+				}
+
+				l.Error("PagerDuty API response", logFields...)
 			}
 
 			// If we fail to publish the alert, we should publish another alert
@@ -138,15 +142,19 @@ func (p pagerDuty) Publish(
 		event.Payload.Summary += ": " + summary
 	}
 
-	// "instance" is set by scraper, but "instance_name" is more readable
 	// Source in payload should be "unique location of the affected system"
 	// as per PagerDuty docs
-	event.Payload.Source = alert.Labels["instance"]
-	if src := alert.Labels["instance_name"]; src != "" {
-		event.Payload.Source = src
-	}
-	if event.Payload.Source == "" {
-		// If no source is set, set dummy value.
+	id := alert.Labels["instance"]
+	name := alert.Labels["instance_name"]
+	switch {
+	case id != "" && name != "":
+		event.Payload.Source = fmt.Sprintf("%s (%s)", name, id)
+	case id != "":
+		event.Payload.Source = id
+	case name != "":
+		event.Payload.Source = name
+	default:
+		// If no instance is set, set dummy value.
 		// This field is required by PagerDuty API.
 		event.Payload.Source = "unknown"
 	}


### PR DESCRIPTION
Couple of changes:
- Add "client" field, it should help with rendering long grafana links.
- Set alert payload source correctly, it should be instance id/name.
- Improve logging a bit, log events always once before sending.
