### PR TITLE
Fix dedup panic and spurious AMPAlertsSinkParseError alerts

### DIFF
--- a/db/dynamo_db.go
+++ b/db/dynamo_db.go
@@ -149,14 +149,13 @@ func (ddb *dynamoDb) Get(
 		return "", nil
 	}
 
+	// A lock item (written by Lock) has no "value" attribute, so the lookup
+	// returns a nil *AttributeValue; guard against it before dereferencing.
 	value := output.Item[ddbKeyValue]
-	switch {
-	// TODO: fill-in other case?
-	case value.S != nil:
-		return *value.S, nil
-	default:
+	if value == nil || value.S == nil {
 		return "", nil
 	}
+	return *value.S, nil
 }
 
 func (ddb *dynamoDb) WithNamespace(namespace string) DB {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -141,6 +141,13 @@ func (p *Processor) processMessage(
 		// publish
 		for _, pub := range p.publishers {
 			if err := pub.Publish(ctx, source, &alert); err != nil {
+				// Losing the dedup lock race just means an HA peer got there
+				// first and is publishing this alert for us. Nothing went
+				// wrong, so skip it quietly instead of failing and alerting.
+				if errors.Is(err, publisher.ErrAlreadyLocked) {
+					l.Debug("Skipped publishing; another instance holds the dedup lock")
+					continue
+				}
 				errs = append(errs, err)
 			}
 		}

--- a/processor/sns_dedup_test.go
+++ b/processor/sns_dedup_test.go
@@ -1,0 +1,78 @@
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/flashbots/amp-alerts-sink/publisher"
+	"github.com/flashbots/amp-alerts-sink/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// stubPublisher records every published alert and returns a fixed error.
+type stubPublisher struct {
+	err   error
+	calls []types.AlertmanagerAlert
+}
+
+func (s *stubPublisher) Publish(_ context.Context, _ string, alert *types.AlertmanagerAlert) error {
+	s.calls = append(s.calls, *alert)
+	return s.err
+}
+
+func newTestProcessor(pub publisher.Publisher) *Processor {
+	return &Processor{
+		ignoreRules: map[string]struct{}{},
+		matchLabels: map[string]string{},
+		log:         zap.NewNop(),
+		publishers:  []publisher.Publisher{pub},
+	}
+}
+
+func snsEventWithAlert(t *testing.T) events.SNSEvent {
+	t.Helper()
+	raw, err := json.Marshal(types.AlertmanagerMessage{
+		Status: "firing",
+		Alerts: []types.AlertmanagerAlert{{
+			Status:   "firing",
+			StartsAt: "2026-06-05T20:06:20Z",
+			Labels:   map[string]string{"alertname": "SomeAlert", "severity": "warning"},
+		}},
+	})
+	require.NoError(t, err)
+	return events.SNSEvent{Records: []events.SNSEventRecord{{
+		SNS: events.SNSEntity{TopicArn: "test-topic", Message: string(raw)},
+	}}}
+}
+
+// When an HA peer wins the dedup lock race, the publisher returns
+// ErrAlreadyLocked. That's a normal, harmless outcome: the invocation should
+// still succeed and no AMPAlertsSinkParseError alert should go out.
+func TestProcessSnsEvent_AlreadyLockedSucceeds(t *testing.T) {
+	pub := &stubPublisher{err: publisher.ErrAlreadyLocked}
+	p := newTestProcessor(pub)
+
+	err := p.ProcessSnsEvent(context.Background(), snsEventWithAlert(t))
+
+	assert.NoError(t, err)
+	require.Len(t, pub.calls, 1, "only the original alert; no synthetic parse-error alert")
+	assert.Equal(t, "SomeAlert", pub.calls[0].Labels["alertname"])
+}
+
+// A genuine publish error should still fail the invocation and send out the
+// AMPAlertsSinkParseError alert.
+func TestProcessSnsEvent_RealErrorEmitsParseErrorAlert(t *testing.T) {
+	pub := &stubPublisher{err: errors.New("boom")}
+	p := newTestProcessor(pub)
+
+	err := p.ProcessSnsEvent(context.Background(), snsEventWithAlert(t))
+
+	assert.Error(t, err)
+	require.Len(t, pub.calls, 2, "original alert plus synthetic parse-error alert")
+	assert.Equal(t, "AMPAlertsSinkParseError", pub.calls[1].Labels["alertname"])
+}

--- a/publisher/webhook.go
+++ b/publisher/webhook.go
@@ -56,8 +56,8 @@ func (w *webhook) Publish(
 
 	isDup, err := w.checkDupAndLock(ctx, alert)
 	if isDup {
-		// Enter this branch even with non-nil err;
-		// Only for ErrAlreadyLocked, so that lambda execution will be restarted
+		// A non-nil err here is always ErrAlreadyLocked, which the processor
+		// now handles as a harmless duplicate (an HA peer will publish it).
 		l.Info("Duplicate alert detected", zap.Error(err))
 		return err
 	}


### PR DESCRIPTION
AMPAlertsSinkParseError was firing without any actual parse errors.

Two DynamoDB-dedup bugs under concurrent/HA-duplicated SNS deliveries:
1. db.Get panicked on lock items lacking a value attribute.
2. Losing the dedup lock race (ErrAlreadyLocked) was treated as a processing error, emitting a spurious critical alert and failing the invocation (causing SNS retries that amplified the contention).

Adds a regression test.

